### PR TITLE
Support default docker and weak docker profiles

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -31,6 +31,12 @@
                 <option value="36109">36109</option>
                 <option value="36110">36110</option>
             </select>
+            <br>
+            <a href="https://github.com/kinvolk/container-escape-bounty/blob/master/Documentation/profiles.md"> Profile:</a>
+            <select name="profile">
+              <option value="default-docker">default-docker</option>
+              <option value="weak-docker">weak-docker</option>
+            </select>
             <br><br><br>
             <input type = "submit" name = "submit" value = "Submit" />
             <br>


### PR DESCRIPTION
The weak docker profile is not complete, but with this PR the user can now select from a dropdown of available docker profiles, which lets the container be run with non-root or root user.