### PR TITLE
frontend: Allow to unselect the open container port

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,9 +16,9 @@
         <form action="term.html">
             Image Name: <input type = "text" name = "image" />
             <br>
-            Contianer Port:
+            Open Container Port:
             <select name="port">
-                <option style="display:none"/>
+                <option/>
                 <option value="36100">36100</option>
                 <option value="36101">36101</option>
                 <option value="36102">36102</option>


### PR DESCRIPTION
When you clicked on a port, there was no way to remove it again.
I've also fixed a typo and renamed the label to be more specific (`Open Container Port: `).