### PR TITLE
Restore local/test development mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ dind: stop-dind ## Starts a docker-in-docker container for running the tests wit
 		--tmpfs /var/lib/docker \
 		--name $(NAME)-dind \
 		--privileged \
-		-p 10000:10000 \
+		-p 10000:10000 -p 36100-36110:36100-36110 \
 		-v $(CURDIR)/.certs:/etc/docker/ssl \
 		$(REGISTRY)/docker:userns \
 		dockerd -D --storage-driver $(DOCKER_GRAPHDRIVER) \
@@ -51,7 +51,8 @@ run: dind setuphostdir image ## Run the server locally in a docker container.
 		$(REGISTRY)/$(NAME) -d \
 		--dcacert=/etc/docker/ssl/cacert.pem \
 		--dcert=/etc/docker/ssl/client.cert \
-		--dkey=/etc/docker/ssl/client.key
+		--dkey=/etc/docker/ssl/client.key \
+		--tlsws $(ARGS)
 
 DOCKER_FLAGS+=--rm -i \
 	--disable-content-trust=true

--- a/README.md
+++ b/README.md
@@ -1,33 +1,27 @@
-# contained.af
+# Container Escape Bounty CTF version of contained.af
 
-[![Travis CI](https://img.shields.io/travis/genuinetools/contained.af.svg?style=for-the-badge)](https://travis-ci.org/genuinetools/contained.af)
-[![GoDoc](https://img.shields.io/badge/godoc-reference-5272B4.svg?style=for-the-badge)](https://godoc.org/github.com/genuinetools/contained.af)
-[![Github All Releases](https://img.shields.io/github/downloads/genuinetools/contained.af/total.svg?style=for-the-badge)](https://github.com/genuinetools/contained.af/releases)
+This is a fork of [contained.af](https://github.com/genuinetools/contained.af)
+(a [game](https://contained.af/) for learning about containers, capabilities, and syscalls).
+It is used in the [Container Escape Bounty CTF](https://github.com/kinvolk/container-escape-bounty)
+which defines container profiles and creates VMs.
+On these VMs a researcher can spawn containers through a web interface
+and has to break out.
 
-A game for learning about containers, capabilities, and syscalls.
+## Usage
+This is intended to be used from the terraform files in other repository linked above.
+The defined profiles can only be tested on real VMs.
 
-To add a question edit this file: [frontend/js/questions.js](frontend/js/questions.js).
+## Local Test/Development Mode
 
-<!-- toc -->
+To spare the time creating a cluster, there are makefiles inherited from contained.af
+that use a Docker-in-Docker setup.
 
-- [Run contained.af locally](#run-containedaf-locally)
-
-<!-- tocstop -->
-
-## Run contained.af locally
-
-Contained is made of a few components:
+These are the components involved:
 
   * A static HTML and JavaScript frontend in `frontend/`
   * A Go web server in the project root
   * An isolated Docker installation, running inside a Docker container
     ("Docker-in-Docker").
-
-Prepare the static frontend assets with:
-
-```
-make dev
-```
 
 Start an isolated Docker instance in the background with:
 
@@ -39,6 +33,13 @@ Build and run the server with:
 
 ```
 make run
+```
+
+To show the button to disable SELinux or AppArmor, you need to provide
+either `fedora` or `ubuntu` in the OS variable:
+
+```
+make run ARGS="-os fedora"
 ```
 
 After a few moments, contained will be available at http://localhost:10000/.

--- a/docker.go
+++ b/docker.go
@@ -259,8 +259,12 @@ func (h *handler) startContainer(ctrInfo *containerInfo) (*websocket.Conn, error
 		"stderr": []string{"1"},
 		"stream": []string{"1"},
 	}
-	wsURL := fmt.Sprintf("ws://%s/%s/containers/%s/attach/ws?%s",
-		h.url(ctrInfo.userns).Host, dockerAPIVersion, r.ID, v.Encode())
+	proto := "ws"
+	if h.tls_ws {
+		proto = "wss"
+	}
+	wsURL := fmt.Sprintf("%s://%s/%s/containers/%s/attach/ws?%s",
+		proto, h.url(ctrInfo.userns).Host, dockerAPIVersion, r.ID, v.Encode())
 	var dialer = &websocket.Dialer{
 		Proxy:           http.ProxyFromEnvironment,
 		TLSClientConfig: h.tlsConfig,

--- a/main.go
+++ b/main.go
@@ -36,7 +36,8 @@ var (
 	staticDir string
 	port      string
 
-	debug bool
+	debug  bool
+	tls_ws bool
 )
 
 func main() {
@@ -63,6 +64,7 @@ func main() {
 	p.FlagSet.StringVar(&port, "port", "10000", "port for server")
 
 	p.FlagSet.BoolVar(&debug, "d", false, "enable debug logging")
+	p.FlagSet.BoolVar(&tls_ws, "tlsws", false, "enable TLS for container websocket")
 
 	// Set the before function.
 	p.Before = func(ctx context.Context) error {
@@ -110,9 +112,14 @@ func main() {
 		}
 
 		c := &http.Client{
-			Transport: &http.Transport{
-				// TLSClientConfig: &tlsConfig,
-			},
+			Transport: &http.Transport{},
+		}
+		if tls_ws {
+			c = &http.Client{
+				Transport: &http.Transport{
+					TLSClientConfig: &tlsConfig,
+				},
+			}
 		}
 
 		if dockerCert != "" && dockerKey != "" {
@@ -141,6 +148,7 @@ func main() {
 
 			dUserNSCli:      dockerUserNSCLI,
 			dockerUserNSURL: dockerUserNSURL,
+			tls_ws:          tls_ws,
 		}
 
 		// ping handler

--- a/server.go
+++ b/server.go
@@ -34,6 +34,7 @@ type handler struct {
 	dockerUserNSURL *url.URL
 
 	tlsConfig *tls.Config
+	tls_ws     bool
 }
 
 func (h *handler) client(userns bool) *client.Client {


### PR DESCRIPTION
While the Container Escape Bounty CTF
profiles are only defined on real VMs,
it is still useful to have a local mode
for testing and development.

This restores the Docker-in-Docker functionality
that was broken when the switch from wss:// to ws://
happened and TLSClientConfig was commented out.
This is done by introducing a new parameter --tlsws.
The SELinux/AppArmor button can be shown when the
OS flag is specified through make run ARGS="-os fedora"
(or ubuntu). The commit also adds the necessary
port forwarding in the Makefile for "make dind".
Finally, the README is updated to reflect that.

Signed-off-by: Kai Lüke <kai@kinvolk.io>